### PR TITLE
Add Boilerplates sub-category and include Alaska boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 ## Contents
 - [Websites](#websites)
 - [Tools](#tools)
+  - [Frameworks](#frameworks)
+  - [Boilerplates](#boilerplates)
 - [Books](#books)
 - [Posts](#posts)
 - [Videos](#videos)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Hoping to keep this list updated as much as possible, any new links through PRs 
 - [Silex (implementation example)](https://gist.github.com/kylekatarnls/ba13e4361ab14f4ff5d2a5775eb0cc10)
 - [Rails](https://github.com/yivo/pug-rails)
 
+### Boilerplates
+- [Alaska](https://github.com/pixelsbyeryc/alaska) - :gear: Static site boilerplate. Using Gulp, PugJS, and Sass.
+
 
 ## Books
 - [Programming Web Applications with Node, Express and Pug](https://www.apress.com/gp/book/9781484225103)


### PR DESCRIPTION
Alaska is a simple boilerplate that uses PugJS, Sass, and Gulp to generate static sites.

It's `CC0` being maintained by myself.